### PR TITLE
Use unique order of public keys and add check private key usage.

### DIFF
--- a/hasher.js
+++ b/hasher.js
@@ -50,7 +50,7 @@ const Hasher = class Hasher{
         hash_array.push(this.hash_string(array[i].encode('hex').toString()));
       }else{
         hash_array.push(array[i]);
-        console.log("i "+i+ "array[i]"+array[i]);
+        //console.log("i "+i+ "array[i]"+array[i]);
         //throw 'hash_array() case not implemented';
       }
     }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 const Hasher = require('./hasher.js');
 const PrivateKey = require('./private-key.js');
-const PublicKey = require('./public-key.js');
 const Prng = require('./prng.js');
-const Signature = require('./signature.js');
 
 const prng = new Prng.Prng();
 //console.log(prng);
@@ -10,21 +8,54 @@ const hasher = new Hasher.Hasher();
 //console.log(hasher)
 const key = new PrivateKey.PrivateKey(prng.random,hasher);
 
-//console.log(key);
+
+const make_unique_id = (key) => [key.point.x.toString(16), key.point.y.toString(16), key.point.z.toString(16)].join('')
+
+const sort_by_unique_id = (key1, key2) => {
+    if (make_unique_id(key1) < make_unique_id(key2)) {
+        return -1
+    }
+    return 1
+}
+
 
 const foreign_keys = [new PrivateKey.PrivateKey(prng.random,hasher).public_key,
                       new PrivateKey.PrivateKey(prng.random,hasher).public_key,
-                      new PrivateKey.PrivateKey(prng.random,hasher).public_key];
+                      new PrivateKey.PrivateKey(prng.random,hasher).public_key,
+                      key.public_key
+                    ];
 
+// Sort public keys into always same order.
+foreign_keys.sort(sort_by_unique_id)
 
 const foreign_keys2 = [new PrivateKey.PrivateKey(prng.random,hasher).public_key,
                       new PrivateKey.PrivateKey(prng.random,hasher).public_key,
-                      new PrivateKey.PrivateKey(prng.random,hasher).public_key];
+                      new PrivateKey.PrivateKey(prng.random,hasher).public_key,
+                      key.public_key
+                    ];
+foreign_keys2.sort(sort_by_unique_id)
 
 const msg = 'one ring to rule them all';
-//console.log(msg)
-const signature = key.sign(msg,foreign_keys);
-const public_keys = signature.public_keys;
 
-console.log(signature.verify(msg,public_keys));
-console.log(signature.verify(msg,foreign_keys2));
+let signatures_tags = []
+
+const check_signature = (signature, name) => {
+    console.log(`Verify signature ${name} by foreign_keys:`)
+    console.log(signature.verify(msg, foreign_keys))
+    console.log(`Verify signature ${name} by foreign_keys2:`)
+    console.log(signature.verify(msg, foreign_keys2))
+
+    if (signatures_tags.includes(signature.key_image)) {
+        console.error(`ERROR: A private key in signature ${name} was already used.`)
+    } else {
+        console.log(`OK. A private key in signature ${name} was not used yet.`)
+        signatures_tags.push(signature.key_image)
+    }
+    console.log("---")
+}
+
+const signature1 = key.sign(msg, foreign_keys)
+check_signature(signature1, '1')
+
+const signature2 = key.sign(msg, foreign_keys)
+check_signature(signature2, '2')

--- a/private-key.js
+++ b/private-key.js
@@ -20,9 +20,10 @@ const PrivateKey = class PrivateKey{
     console.log(message)
     const seed = this.hasher.hash_array([this.value,message_digest]);
 
-    let all_keys = foreign_keys.slice();
-    all_keys.push(this);
-    shuffle(all_keys);
+    let all_keys = [];
+    for (let i=0; i < foreign_keys.length; i++) {
+      all_keys.push(foreign_keys[i] === this.public_key ? this : foreign_keys[i])
+    }
 
     const q_array = this.generate_q(all_keys,seed); // hex numbers
     const w_array = this.generate_w(all_keys,seed); // hex number + 1 BN
@@ -38,16 +39,7 @@ const PrivateKey = class PrivateKey{
     const c_array = this.generate_c(all_keys,q_array,w_array,challenge);
     const r_array = this.generate_r(all_keys,q_array,w_array,c_array,challenge);
 
-    let public_keys = [];
-    for(let i=0;i<all_keys.length;i++){
-      if(all_keys[i] instanceof PrivateKey){
-        public_keys.push(all_keys[i].public_key);
-      }else{
-        public_keys.push(all_keys[i]);
-      }
-    }
-
-    return new Signature.Signature(this.key_image,c_array,r_array,public_keys,this.hasher);
+    return new Signature.Signature(this.key_image,c_array,r_array,this.hasher);
   }
 
   generate_r(all_keys,q_array,w_array,c_array,challenge){

--- a/signature.js
+++ b/signature.js
@@ -1,12 +1,11 @@
 const BN = require('bn.js');
 
 const Signature = class Signature{
-  constructor(key_image,c_array,r_array,public_keys,hasher){
+  constructor(key_image,c_array,r_array,hasher){
     this.key_image = key_image;
     this.c_array = c_array;
     this.r_array = r_array;
     this.hasher = hasher;
-    this.public_keys = public_keys
   }
 
   verify(message,public_keys){


### PR DESCRIPTION
This is my suggestion how to deal order of public keys. It must be always same, otherwise verification fails.

I added simple example of check usage private key in signature.